### PR TITLE
Saving document links on Room Database

### DIFF
--- a/application/core/persistence_room/src/commonMain/kotlin/io/writeopia/persistence/room/WriteopiaAplicationDatabase.kt
+++ b/application/core/persistence_room/src/commonMain/kotlin/io/writeopia/persistence/room/WriteopiaAplicationDatabase.kt
@@ -37,7 +37,7 @@ expect object AppDatabaseConstructor : RoomDatabaseConstructor<WriteopiaApplicat
         UserEntity::class,
         TokenEntity::class
     ],
-    version = 22,
+    version = 23,
     exportSchema = false
 )
 @TypeConverters(IdListConverter::class)

--- a/plugins/writeopia_persistence_room/src/commonMain/kotlin/io/writeopia/sdk/persistence/dao/DocumentEntityDao.kt
+++ b/plugins/writeopia_persistence_room/src/commonMain/kotlin/io/writeopia/sdk/persistence/dao/DocumentEntityDao.kt
@@ -128,4 +128,7 @@ interface DocumentEntityDao {
 
     @Query("UPDATE $DOCUMENT_ENTITY set user_id = :newUserId WHERE user_id = :oldUserId")
     suspend fun moveDocumentsToNewUser(oldUserId: String, newUserId: String)
+
+    @Query("SELECT title FROM $DOCUMENT_ENTITY WHERE $DOCUMENT_ENTITY.id = :documentId")
+    suspend fun getDocumentTitleById(documentId: String): String?
 }

--- a/plugins/writeopia_persistence_room/src/commonMain/kotlin/io/writeopia/sdk/persistence/entity/story/StoryStepEntity.kt
+++ b/plugins/writeopia_persistence_room/src/commonMain/kotlin/io/writeopia/sdk/persistence/entity/story/StoryStepEntity.kt
@@ -23,4 +23,5 @@ data class StoryStepEntity(
     @ColumnInfo(name = "background_color") val backgroundColor: Int?,
     @ColumnInfo(name = "tags") val tags: String,
     @ColumnInfo(name = "spans") val spans: String,
+    @ColumnInfo(name = "link_to_document") val linkToDocument: String? = null
 )

--- a/plugins/writeopia_persistence_room/src/commonMain/kotlin/io/writeopia/sdk/persistence/parse/StoryUnitParse.kt
+++ b/plugins/writeopia_persistence_room/src/commonMain/kotlin/io/writeopia/sdk/persistence/parse/StoryUnitParse.kt
@@ -1,5 +1,6 @@
 package io.writeopia.sdk.persistence.parse
 
+import io.writeopia.sdk.models.link.DocumentLink
 import io.writeopia.sdk.models.span.SpanInfo
 import io.writeopia.sdk.models.story.Decoration
 import io.writeopia.sdk.models.story.StoryStep
@@ -23,7 +24,8 @@ fun StoryStepEntity.toModel(
     steps: List<StoryStepEntity> = emptyList(),
     nameToType: (String) -> StoryType = { typeName ->
         StoryTypes.fromName(typeName).type
-    }
+    },
+    documentLink: DocumentLink? = null,
 ): StoryStep =
     StoryStep(
         id = id,
@@ -47,7 +49,8 @@ fun StoryStepEntity.toModel(
             .split(",")
             .filter { it.isNotEmpty() }
             .map(SpanInfo::fromString)
-            .toSet()
+            .toSet(),
+        documentLink = documentLink
     )
 
 fun StoryStep.toEntity(position: Int, documentId: String): StoryStepEntity =
@@ -66,5 +69,6 @@ fun StoryStep.toEntity(position: Int, documentId: String): StoryStepEntity =
         hasInnerSteps = this.steps.isNotEmpty(),
         backgroundColor = this.decoration.backgroundColor,
         tags = this.tags.joinToString(separator = ",") { it.tag.label },
-        spans = this.spans.joinToString(separator = ",") { it.toText() }
+        spans = this.spans.joinToString(separator = ",") { it.toText() },
+        linkToDocument = documentLink?.id
     )


### PR DESCRIPTION
## General
Now, the Room Database will save document links.

These document links are being used to Link a message inside a Page to another Page.


## Steps
- Adding the `link_to_document` column.
- Increasing Room Database Version (this will delete all user data of plataforms that uses Room)
- Parsing the new column on `StoryUnitParse.kt`
- Retrieving the `DocumentLink`, using the ID and the title of pointed page, searching the title with the page ID, on `RoomDocumentRepository.kt`